### PR TITLE
Prevent «Class 'App\Http\Controllers\Controller' not found»

### DIFF
--- a/src/Http/Controllers/GroupController.php
+++ b/src/Http/Controllers/GroupController.php
@@ -7,7 +7,7 @@ use ToxicLemurs\MenuBuilder\Http\Requests\GroupPostRequest;
 use ToxicLemurs\MenuBuilder\Http\Requests\GroupPostEditRequest;
 use Illuminate\Routing\Redirector;
 use Illuminate\View\View;
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 
 /**
  * Class GroupController

--- a/src/Http/Controllers/MenuController.php
+++ b/src/Http/Controllers/MenuController.php
@@ -7,7 +7,7 @@ use ToxicLemurs\MenuBuilder\models\Menu as Menu;
 use ToxicLemurs\MenuBuilder\Http\Requests\MenuItemRequest;
 use Illuminate\Routing\Redirector;
 use Illuminate\View\View;
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 
 /**
  * Class MenuController


### PR DESCRIPTION
Renaming the App-namespace ( as per https://laravel.com/docs/5.1/installation#naming-your-application ), results in [Symfony\Component\Debug\Exception\FatalErrorException]  
Class 'App\Http\Controllers\Controller' not found
.
Suggest to use Illuminate\Routing\Controller instead .