### PR TITLE
Switch to using Illuminate\Foundation\Http\FormRequest

### DIFF
--- a/src/Http/Requests/GroupPostEditRequest.php
+++ b/src/Http/Requests/GroupPostEditRequest.php
@@ -6,13 +6,13 @@
 
 namespace ToxicLemurs\MenuBuilder\Http\Requests;
 
-use Illuminate\Http\Request;
+use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Class GroupPostEditRequest
  * @package ToxicLemurs\MenuBuilder\Http\Requests
  */
-class GroupPostEditRequest extends Request
+class GroupPostEditRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/src/Http/Requests/GroupPostRequest.php
+++ b/src/Http/Requests/GroupPostRequest.php
@@ -6,13 +6,13 @@
 
 namespace ToxicLemurs\MenuBuilder\Http\Requests;
 
-use Illuminate\Http\Request;
+use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Class GroupPostRequest
  * @package ToxicLemurs\MenuBuilder\Http\Requests
  */
-class GroupPostRequest extends Request
+class GroupPostRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/src/Http/Requests/MenuItemRequest.php
+++ b/src/Http/Requests/MenuItemRequest.php
@@ -6,13 +6,13 @@
 
 namespace ToxicLemurs\MenuBuilder\Http\Requests;
 
-use Illuminate\Http\Request;
+use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Class MenuItemRequest
  * @package App\Http\Requests
  */
-class MenuItemRequest extends Request
+class MenuItemRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
If i'm not mistaken the `Illuminate\Http\Request` is not auto validated where the `Illuminate\Foundation\Http\FormRequest` is. 